### PR TITLE
chore(ci): add GitHub Actions CI, pre-commit hooks, and Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-and-format:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Ruff lint
+        run: ruff check src/ tests/
+
+      - name: Black format check
+        run: black --check src/ tests/
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests with coverage
+        run: pytest --cov=gtd_mcp --cov-report=xml --cov-report=term-missing
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-merge-conflict
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: [--fix]
+        types_or: [python, pyi]
+
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        language_version: python3.12

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # GTD MCP Server
 
+[![CI](https://github.com/stevesimpson418/gtd-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/stevesimpson418/gtd-mcp-server/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/stevesimpson418/gtd-mcp-server/graph/badge.svg)](https://codecov.io/gh/stevesimpson418/gtd-mcp-server)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 A local [MCP](https://modelcontextprotocol.io/) server that gives Claude native, tool-level access to **Todoist** and **Gmail** for GTD (Getting Things Done) workflows. Runs locally via stdio transport — all tokens and credentials stay on your machine.
 
 ## Prerequisites

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
     "pytest-asyncio>=0.24",
     "black>=24.0",
     "ruff>=0.6.0",
+    "pre-commit>=3.8.0",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI workflow (lint, format check, tests + Codecov upload)
- Add pre-commit config with ruff, black, and general file hygiene hooks
- Add `codecov.yml` coverage reporting configuration
- Update README with CI status, Codecov, Python version, and license badges
- Add `pre-commit` to dev dependencies in `pyproject.toml`

## Test plan

- [ ] CI workflow triggers on merge and passes lint, format, and test jobs
- [ ] Codecov comment appears on PRs with coverage delta (requires `CODECOV_TOKEN` secret set)
- [ ] Run `pre-commit run --all-files` locally to confirm hooks pass