### PR TITLE
fix(todoist): accept list[str] for labels in create_task

### DIFF
--- a/src/gtd_mcp/todoist/tools.py
+++ b/src/gtd_mcp/todoist/tools.py
@@ -14,6 +14,13 @@ from gtd_mcp.todoist.client import TodoistClient
 logger = logging.getLogger(__name__)
 
 
+def _ensure_list(v: str | list[str]) -> list[str]:
+    """Coerce a single string into a one-element list for label params."""
+    if isinstance(v, str):
+        return [v]
+    return v
+
+
 def register_todoist_tools(mcp: FastMCP) -> None:
     """Register all Todoist tools with the MCP server.
 
@@ -100,7 +107,7 @@ def register_todoist_tools(mcp: FastMCP) -> None:
             ),
         ] = "Inbox",
         labels: Annotated[
-            list[str],
+            str | list[str],
             Field(
                 default=[],
                 description=(
@@ -132,6 +139,7 @@ def register_todoist_tools(mcp: FastMCP) -> None:
             content: The task title, e.g. "Buy groceries".
             project: Target project name. Defaults to "Inbox".
             labels: List of label names to apply, e.g. ["Shopping", "Home"].
+                A single string is also accepted and will be wrapped in a list.
             due_date: When it's due — "tomorrow", "next Friday", or "2026-03-15".
             description: Additional notes or details.
 
@@ -142,10 +150,11 @@ def register_todoist_tools(mcp: FastMCP) -> None:
         Returns:
             {"id": "123", "content": "Buy groceries", "labels": ["Shopping"], ...}
         """
+        normalized_labels = _ensure_list(labels) if labels else None
         return client.create_task(
             content=content,
             project=project,
-            labels=labels or None,
+            labels=normalized_labels,
             due_date=due_date or None,
             description=description or None,
         )
@@ -161,7 +170,7 @@ def register_todoist_tools(mcp: FastMCP) -> None:
             ),
         ] = "",
         labels: Annotated[
-            list[str],
+            str | list[str],
             Field(
                 default=[],
                 description=(
@@ -207,10 +216,11 @@ def register_todoist_tools(mcp: FastMCP) -> None:
         Returns:
             {"id": "123", "content": "Buy organic groceries", ...}
         """
+        normalized_labels = _ensure_list(labels) if labels else None
         return client.update_task(
             task_id=task_id,
             content=content or None,
-            labels=labels or None,
+            labels=normalized_labels,
             due_date=due_date or None,
             description=description or None,
         )

--- a/tests/test_todoist_tools.py
+++ b/tests/test_todoist_tools.py
@@ -161,6 +161,41 @@ class TestCreateTask:
             description="Notes",
         )
 
+    def test_delegates_with_multiple_labels(self, mcp_server, mock_client):
+        mock_instance, _ = register_with_token(mcp_server, mock_client)
+        mock_instance.create_task.return_value = {
+            "id": "t1",
+            "content": "Buy groceries",
+            "labels": ["Shopping", "Errands"],
+        }
+
+        fn = get_tool_fn(mcp_server, "create_task")
+        result = fn(content="Buy groceries", labels=["Shopping", "Errands"])
+
+        mock_instance.create_task.assert_called_once_with(
+            content="Buy groceries",
+            project="Inbox",
+            labels=["Shopping", "Errands"],
+            due_date=None,
+            description=None,
+        )
+        assert result["labels"] == ["Shopping", "Errands"]
+
+    def test_coerces_single_string_label_to_list(self, mcp_server, mock_client):
+        mock_instance, _ = register_with_token(mcp_server, mock_client)
+        mock_instance.create_task.return_value = {"id": "t1", "content": "Task"}
+
+        fn = get_tool_fn(mcp_server, "create_task")
+        fn(content="Task", labels="Shopping")
+
+        mock_instance.create_task.assert_called_once_with(
+            content="Task",
+            project="Inbox",
+            labels=["Shopping"],
+            due_date=None,
+            description=None,
+        )
+
 
 class TestUpdateTask:
     def test_delegates_partial_update(self, mcp_server, mock_client):


### PR DESCRIPTION
## Summary
- Fixes `create_task` rejecting `list[str]` for the `labels` parameter
- Changes type annotation to `str | list[str]` and adds `_ensure_list()` coercion
- Also applies the same fix to `update_task` for consistency

Closes #4

## Test plan
- [ ] Verify `create_task(labels=["Shopping", "Errands"])` works
- [ ] Verify `create_task(labels="Shopping")` coerces to list
- [ ] Verify `update_task` handles both forms too
- [ ] All 126 tests pass