### PR TITLE
feat(gmail): add attachment list, read, and download support

### DIFF
--- a/src/gtd_mcp/gmail/client.py
+++ b/src/gtd_mcp/gmail/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import logging
 from email.mime.text import MIMEText
+from pathlib import Path
 
 from gtd_mcp.gmail.exceptions import GmailAPIError
 
@@ -84,6 +85,93 @@ class GmailClient:
             return {"thread_id": thread_id, "message_count": len(messages), "messages": messages}
         except Exception as e:
             raise GmailAPIError(f"Failed to read thread {thread_id}: {e}") from e
+
+    # --- Attachment operations ---
+
+    @staticmethod
+    def _extract_attachment_metadata(payload: dict) -> list[dict]:
+        """Recursively extract attachment metadata from a message payload."""
+        attachments = []
+        for part in payload.get("parts", []):
+            filename = part.get("filename", "")
+            if filename:
+                attachments.append(
+                    {
+                        "attachment_id": part.get("body", {}).get("attachmentId", ""),
+                        "filename": filename,
+                        "mime_type": part.get("mimeType", ""),
+                        "size": part.get("body", {}).get("size", 0),
+                        "part_id": part.get("partId", ""),
+                    }
+                )
+            if "parts" in part:
+                attachments.extend(GmailClient._extract_attachment_metadata(part))
+        return attachments
+
+    def list_attachments(self, message_id: str) -> list[dict]:
+        """List attachments for a message."""
+        try:
+            msg = (
+                self._service.users()
+                .messages()
+                .get(userId="me", id=message_id, format="full")
+                .execute()
+            )
+            return self._extract_attachment_metadata(msg.get("payload", {}))
+        except Exception as e:
+            raise GmailAPIError(f"Failed to list attachments for {message_id}: {e}") from e
+
+    def get_attachment(self, message_id: str, attachment_id: str) -> bytes:
+        """Fetch and decode a raw attachment."""
+        try:
+            response = (
+                self._service.users()
+                .messages()
+                .attachments()
+                .get(userId="me", messageId=message_id, id=attachment_id)
+                .execute()
+            )
+            return base64.urlsafe_b64decode(response["data"])
+        except Exception as e:
+            raise GmailAPIError(
+                f"Failed to get attachment {attachment_id} from {message_id}: {e}"
+            ) from e
+
+    def download_attachment(
+        self, message_id: str, attachment_id: str, filename: str, download_path: str
+    ) -> dict:
+        """Download an attachment to disk."""
+        download_dir = Path(download_path)
+        if not download_dir.is_dir():
+            raise ValueError(f"'{download_path}' is not a valid directory")
+
+        raw_bytes = self.get_attachment(message_id, attachment_id)
+        safe_filename = Path(filename).name
+        file_path = download_dir / safe_filename
+        file_path.write_bytes(raw_bytes)
+        return {"filename": safe_filename, "path": str(file_path), "size": len(raw_bytes)}
+
+    _TEXT_MIME_TYPES = frozenset({"application/json", "application/csv", "application/xml"})
+
+    def read_attachment_content(
+        self, message_id: str, attachment_id: str, filename: str, mime_type: str
+    ) -> dict:
+        """Read attachment content, decoding text types as UTF-8."""
+        raw_bytes = self.get_attachment(message_id, attachment_id)
+        is_text = mime_type.startswith("text/") or mime_type in self._TEXT_MIME_TYPES
+        if is_text:
+            content = raw_bytes.decode("utf-8", errors="replace")
+            encoding = "text"
+        else:
+            content = base64.b64encode(raw_bytes).decode("ascii")
+            encoding = "base64"
+        return {
+            "filename": filename,
+            "mime_type": mime_type,
+            "size": len(raw_bytes),
+            "encoding": encoding,
+            "content": content,
+        }
 
     # --- Label operations ---
 
@@ -318,8 +406,10 @@ class GmailClient:
 
     def _parse_full_message(self, msg: dict) -> dict:
         """Parse a full-format message including body."""
-        headers = msg.get("payload", {}).get("headers", [])
-        body = self._extract_body(msg.get("payload", {}))
+        payload = msg.get("payload", {})
+        headers = payload.get("headers", [])
+        body = self._extract_body(payload)
+        attachments = self._extract_attachment_metadata(payload)
         return {
             "id": msg["id"],
             "thread_id": msg["threadId"],
@@ -331,6 +421,8 @@ class GmailClient:
             "snippet": msg.get("snippet", ""),
             "label_ids": msg.get("labelIds", []),
             "body": body,
+            "has_attachments": len(attachments) > 0,
+            "attachment_count": len(attachments),
         }
 
     @staticmethod

--- a/src/gtd_mcp/gmail/tools.py
+++ b/src/gtd_mcp/gmail/tools.py
@@ -444,6 +444,89 @@ def register_gmail_tools(mcp: FastMCP) -> None:
         """
         return client.send_draft(draft_id)
 
+    # --- Attachments ---
+
+    @mcp.tool(annotations={"readOnlyHint": True})
+    def list_gmail_attachments(
+        message_id: Annotated[str, Field(description="The Gmail message ID.")],
+    ) -> list[dict]:
+        """List attachments on a Gmail message.
+
+        Returns metadata for each attachment (id, filename, mime_type, size).
+        Use with read_gmail_attachment() or download_gmail_attachment().
+
+        Args:
+            message_id: The message ID from search_gmail().
+
+        Example:
+            list_gmail_attachments(message_id="18e2f3a4b5c6d7e8")
+
+        Returns:
+            [{"attachment_id": "att_1", "filename": "report.pdf",
+              "mime_type": "application/pdf", "size": 12345, "part_id": "2"}]
+        """
+        return client.list_attachments(message_id)
+
+    @mcp.tool(annotations={"readOnlyHint": True})
+    def read_gmail_attachment(
+        message_id: Annotated[str, Field(description="The Gmail message ID.")],
+        attachment_id: Annotated[
+            str, Field(description="The attachment ID from list_gmail_attachments().")
+        ],
+        filename: Annotated[str, Field(description="Original filename of the attachment.")],
+        mime_type: Annotated[str, Field(description="MIME type of the attachment.")],
+    ) -> dict:
+        """Read attachment content inline.
+
+        Text files (text/*, JSON, CSV, XML) are returned as decoded text.
+        Binary files (PDF, images, etc.) are returned as base64-encoded strings.
+
+        Args:
+            message_id: The message ID.
+            attachment_id: The attachment ID from list_gmail_attachments().
+            filename: The attachment filename.
+            mime_type: The attachment MIME type.
+
+        Example:
+            read_gmail_attachment(message_id="msg1", attachment_id="att1",
+                                 filename="data.csv", mime_type="text/csv")
+
+        Returns:
+            {"filename": "data.csv", "mime_type": "text/csv", "size": 1234,
+             "encoding": "text", "content": "name,value\\nalice,42"}
+        """
+        return client.read_attachment_content(message_id, attachment_id, filename, mime_type)
+
+    @mcp.tool
+    def download_gmail_attachment(
+        message_id: Annotated[str, Field(description="The Gmail message ID.")],
+        attachment_id: Annotated[
+            str, Field(description="The attachment ID from list_gmail_attachments().")
+        ],
+        filename: Annotated[str, Field(description="Original filename of the attachment.")],
+        download_path: Annotated[
+            str, Field(description="Directory path where the file should be saved.")
+        ],
+    ) -> dict:
+        """Download a Gmail attachment to disk.
+
+        Saves the attachment file to the specified directory.
+
+        Args:
+            message_id: The message ID.
+            attachment_id: The attachment ID from list_gmail_attachments().
+            filename: The attachment filename.
+            download_path: Local directory to save the file.
+
+        Example:
+            download_gmail_attachment(message_id="msg1", attachment_id="att1",
+                                     filename="report.pdf", download_path="/tmp")
+
+        Returns:
+            {"filename": "report.pdf", "path": "/tmp/report.pdf", "size": 12345}
+        """
+        return client.download_attachment(message_id, attachment_id, filename, download_path)
+
     # --- Delete ---
 
     @mcp.tool(annotations={"destructiveHint": True})

--- a/tests/test_gmail_client.py
+++ b/tests/test_gmail_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -463,3 +464,325 @@ class TestExtractBody:
 
     def test_empty_payload(self):
         assert GmailClient._extract_body({}) == ""
+
+
+# --- Attachment helpers ---
+
+
+def make_attachment_message(
+    msg_id: str = "msg_att",
+    attachments: list[dict] | None = None,
+    inline_images: bool = False,
+    nested: bool = False,
+) -> dict:
+    """Build a Gmail message with attachment parts.
+
+    Args:
+        attachments: List of dicts with keys: filename, mime_type, size, attachment_id.
+        inline_images: If True, include an inline image part (no filename).
+        nested: If True, wrap text parts inside a nested multipart/alternative.
+    """
+    if attachments is None:
+        attachments = [
+            {
+                "filename": "report.pdf",
+                "mime_type": "application/pdf",
+                "size": 12345,
+                "attachment_id": "att_1",
+            }
+        ]
+
+    plain_body = base64.urlsafe_b64encode(b"Email body text").decode()
+
+    text_part = {"mimeType": "text/plain", "body": {"data": plain_body}}
+    attachment_parts = []
+    for att in attachments:
+        attachment_parts.append(
+            {
+                "partId": f"part_{att['attachment_id']}",
+                "mimeType": att["mime_type"],
+                "filename": att["filename"],
+                "body": {
+                    "attachmentId": att["attachment_id"],
+                    "size": att["size"],
+                },
+            }
+        )
+
+    parts = []
+    if nested:
+        html_body = base64.urlsafe_b64encode(b"<p>Email body</p>").decode()
+        parts.append(
+            {
+                "mimeType": "multipart/alternative",
+                "parts": [
+                    text_part,
+                    {"mimeType": "text/html", "body": {"data": html_body}},
+                ],
+            }
+        )
+    else:
+        parts.append(text_part)
+
+    if inline_images:
+        parts.append(
+            {
+                "partId": "part_inline",
+                "mimeType": "image/png",
+                "filename": "",
+                "body": {"attachmentId": "inline_1", "size": 500},
+                "headers": [
+                    {"name": "Content-Disposition", "value": "inline"},
+                ],
+            }
+        )
+
+    parts.extend(attachment_parts)
+
+    return {
+        "id": msg_id,
+        "threadId": "thread_1",
+        "snippet": "Preview...",
+        "labelIds": ["INBOX"],
+        "payload": {
+            "headers": [
+                {"name": "Subject", "value": "With attachments"},
+                {"name": "From", "value": "sender@example.com"},
+                {"name": "Date", "value": "Wed, 3 Mar 2026"},
+                {"name": "To", "value": "me@example.com"},
+                {"name": "Cc", "value": ""},
+            ],
+            "mimeType": "multipart/mixed",
+            "parts": parts,
+        },
+    }
+
+
+# --- List attachments tests ---
+
+
+class TestListAttachments:
+    def test_multipart_with_attachments(self):
+        client, svc = make_client()
+        msg = make_attachment_message(
+            attachments=[
+                {
+                    "filename": "report.pdf",
+                    "mime_type": "application/pdf",
+                    "size": 12345,
+                    "attachment_id": "att_1",
+                },
+                {
+                    "filename": "data.csv",
+                    "mime_type": "text/csv",
+                    "size": 678,
+                    "attachment_id": "att_2",
+                },
+            ]
+        )
+        svc.users().messages().get().execute.return_value = msg
+
+        result = client.list_attachments("msg_att")
+        assert len(result) == 2
+        assert result[0]["filename"] == "report.pdf"
+        assert result[0]["mime_type"] == "application/pdf"
+        assert result[0]["size"] == 12345
+        assert result[0]["attachment_id"] == "att_1"
+        assert result[0]["part_id"] == "part_att_1"
+        assert result[1]["filename"] == "data.csv"
+
+    def test_no_attachments(self):
+        client, svc = make_client()
+        msg = make_multipart_message()
+        svc.users().messages().get().execute.return_value = msg
+
+        result = client.list_attachments("msg_1")
+        assert result == []
+
+    def test_inline_images_excluded(self):
+        client, svc = make_client()
+        msg = make_attachment_message(inline_images=True)
+        svc.users().messages().get().execute.return_value = msg
+
+        result = client.list_attachments("msg_att")
+        assert len(result) == 1
+        assert result[0]["filename"] == "report.pdf"
+
+    def test_nested_multipart(self):
+        client, svc = make_client()
+        msg = make_attachment_message(nested=True)
+        svc.users().messages().get().execute.return_value = msg
+
+        result = client.list_attachments("msg_att")
+        assert len(result) == 1
+        assert result[0]["filename"] == "report.pdf"
+
+
+# --- Get attachment tests ---
+
+
+class TestGetAttachment:
+    def test_fetch_and_decode(self):
+        client, svc = make_client()
+        raw_data = b"PDF file contents here"
+        encoded = base64.urlsafe_b64encode(raw_data).decode()
+        svc.users().messages().attachments().get().execute.return_value = {
+            "data": encoded,
+            "size": len(raw_data),
+        }
+
+        result = client.get_attachment("msg_1", "att_1")
+        assert result == raw_data
+
+    def test_api_error(self):
+        client, svc = make_client()
+        svc.users().messages().attachments().get().execute.side_effect = Exception("Not found")
+
+        with pytest.raises(GmailAPIError, match="Failed to get attachment"):
+            client.get_attachment("msg_1", "bad_att")
+
+
+# --- Read attachment content tests ---
+
+
+class TestReadAttachmentContent:
+    def test_text_csv_decoded(self):
+        client, svc = make_client()
+        csv_data = b"name,value\nalice,42"
+        encoded = base64.urlsafe_b64encode(csv_data).decode()
+        svc.users().messages().attachments().get().execute.return_value = {
+            "data": encoded,
+            "size": len(csv_data),
+        }
+
+        result = client.read_attachment_content("msg_1", "att_1", "data.csv", "text/csv")
+        assert result["encoding"] == "text"
+        assert result["content"] == "name,value\nalice,42"
+        assert result["filename"] == "data.csv"
+        assert result["mime_type"] == "text/csv"
+        assert result["size"] == len(csv_data)
+
+    def test_binary_pdf_base64(self):
+        client, svc = make_client()
+        pdf_data = b"%PDF-1.4 binary content"
+        encoded = base64.urlsafe_b64encode(pdf_data).decode()
+        svc.users().messages().attachments().get().execute.return_value = {
+            "data": encoded,
+            "size": len(pdf_data),
+        }
+
+        result = client.read_attachment_content("msg_1", "att_1", "doc.pdf", "application/pdf")
+        assert result["encoding"] == "base64"
+        assert base64.b64decode(result["content"]) == pdf_data
+
+    def test_json_as_text(self):
+        client, svc = make_client()
+        json_data = b'{"key": "value"}'
+        encoded = base64.urlsafe_b64encode(json_data).decode()
+        svc.users().messages().attachments().get().execute.return_value = {
+            "data": encoded,
+            "size": len(json_data),
+        }
+
+        result = client.read_attachment_content("msg_1", "att_1", "data.json", "application/json")
+        assert result["encoding"] == "text"
+        assert result["content"] == '{"key": "value"}'
+
+    def test_xml_as_text(self):
+        client, svc = make_client()
+        xml_data = b"<root><item>value</item></root>"
+        encoded = base64.urlsafe_b64encode(xml_data).decode()
+        svc.users().messages().attachments().get().execute.return_value = {
+            "data": encoded,
+            "size": len(xml_data),
+        }
+
+        result = client.read_attachment_content("msg_1", "att_1", "data.xml", "application/xml")
+        assert result["encoding"] == "text"
+        assert result["content"] == "<root><item>value</item></root>"
+
+
+# --- Download attachment tests ---
+
+
+class TestDownloadAttachment:
+    def test_saves_file(self, tmp_path):
+        client, svc = make_client()
+        file_data = b"file contents"
+        encoded = base64.urlsafe_b64encode(file_data).decode()
+        svc.users().messages().attachments().get().execute.return_value = {
+            "data": encoded,
+            "size": len(file_data),
+        }
+
+        result = client.download_attachment("msg_1", "att_1", "report.pdf", str(tmp_path))
+        assert result["filename"] == "report.pdf"
+        assert result["size"] == len(file_data)
+        saved = Path(result["path"])
+        assert saved.exists()
+        assert saved.read_bytes() == file_data
+
+    def test_invalid_dir_raises(self):
+        client, _ = make_client()
+        with pytest.raises(ValueError, match="not a valid directory"):
+            client.download_attachment("msg_1", "att_1", "file.pdf", "/nonexistent/path")
+
+    def test_path_traversal_sanitized(self, tmp_path):
+        client, svc = make_client()
+        file_data = b"data"
+        encoded = base64.urlsafe_b64encode(file_data).decode()
+        svc.users().messages().attachments().get().execute.return_value = {
+            "data": encoded,
+            "size": len(file_data),
+        }
+
+        result = client.download_attachment("msg_1", "att_1", "../../etc/passwd", str(tmp_path))
+        assert result["filename"] == "passwd"
+        assert str(tmp_path) in result["path"]
+
+
+# --- _parse_full_message attachment fields ---
+
+
+class TestParseFullMessageAttachments:
+    def test_has_attachments_true(self):
+        client, _ = make_client()
+        msg = make_attachment_message()
+        result = client._parse_full_message(msg)
+        assert result["has_attachments"] is True
+        assert result["attachment_count"] == 1
+
+    def test_has_attachments_false(self):
+        client, _ = make_client()
+        msg = make_message()
+        result = client._parse_full_message(msg)
+        assert result["has_attachments"] is False
+        assert result["attachment_count"] == 0
+
+    def test_multiple_attachments_count(self):
+        client, _ = make_client()
+        msg = make_attachment_message(
+            attachments=[
+                {
+                    "filename": "a.pdf",
+                    "mime_type": "application/pdf",
+                    "size": 100,
+                    "attachment_id": "att_1",
+                },
+                {
+                    "filename": "b.csv",
+                    "mime_type": "text/csv",
+                    "size": 200,
+                    "attachment_id": "att_2",
+                },
+                {
+                    "filename": "c.docx",
+                    "mime_type": "application/vnd.openxmlformats",
+                    "size": 300,
+                    "attachment_id": "att_3",
+                },
+            ]
+        )
+        result = client._parse_full_message(msg)
+        assert result["has_attachments"] is True
+        assert result["attachment_count"] == 3

--- a/tests/test_gmail_client.py
+++ b/tests/test_gmail_client.py
@@ -466,6 +466,73 @@ class TestExtractBody:
         assert GmailClient._extract_body({}) == ""
 
 
+# --- Get header edge case ---
+
+
+class TestGetHeader:
+    def test_missing_header_returns_empty(self):
+        result = GmailClient._get_header([{"name": "Subject", "value": "Hi"}], "X-Not-Present")
+        assert result == ""
+
+
+# --- List labels error ---
+
+
+class TestListLabelsError:
+    def test_api_error(self):
+        client, svc = make_client()
+        svc.users().labels().list().execute.side_effect = Exception("Fail")
+
+        with pytest.raises(GmailAPIError, match="Failed to list labels"):
+            client.list_labels()
+
+
+# --- Create label edge cases ---
+
+
+class TestCreateLabelExtended:
+    def test_create_label_with_colors(self):
+        client, svc = make_client()
+        svc.users().labels().create().execute.return_value = {
+            "id": "Label_color",
+            "name": "Urgent",
+        }
+
+        result = client.create_label("Urgent", text_color="#ffffff", background_color="#cc3a21")
+        assert result == {"id": "Label_color", "name": "Urgent"}
+
+    def test_create_label_api_error(self):
+        client, svc = make_client()
+        svc.users().labels().create().execute.side_effect = Exception("Fail")
+
+        with pytest.raises(GmailAPIError, match="Failed to create label"):
+            client.create_label("Bad")
+
+
+# --- Modify messages error ---
+
+
+class TestModifyMessagesError:
+    def test_api_error(self):
+        client, svc = make_client()
+        svc.users().messages().batchModify().execute.side_effect = Exception("Fail")
+
+        with pytest.raises(GmailAPIError, match="Failed to modify messages"):
+            client.mark_read(["msg_1"])
+
+
+# --- Trash outer exception ---
+
+
+class TestTrashOuterError:
+    def test_non_iterable_message_ids(self):
+        """Trigger the outer except in trash_messages."""
+        client, svc = make_client()
+        # Passing a non-iterable triggers the outer try/except
+        with pytest.raises(GmailAPIError, match="Failed to trash messages"):
+            client.trash_messages(None)
+
+
 # --- Attachment helpers ---
 
 
@@ -616,6 +683,13 @@ class TestListAttachments:
         result = client.list_attachments("msg_att")
         assert len(result) == 1
         assert result[0]["filename"] == "report.pdf"
+
+    def test_api_error(self):
+        client, svc = make_client()
+        svc.users().messages().get().execute.side_effect = Exception("Fail")
+
+        with pytest.raises(GmailAPIError, match="Failed to list attachments"):
+            client.list_attachments("bad_id")
 
 
 # --- Get attachment tests ---

--- a/tests/test_gmail_tools.py
+++ b/tests/test_gmail_tools.py
@@ -94,6 +94,38 @@ class TestRegistration:
 
         assert len(get_tool_names(mcp_server)) == 0
 
+    def test_no_tools_when_credentials_not_found(self, mcp_server):
+        with (
+            patch("gtd_mcp.gmail.tools.GmailAuth") as mock_auth_cls,
+            patch.dict(
+                os.environ,
+                {
+                    "GMAIL_CREDENTIALS_PATH": "/fake/creds.json",
+                    "GMAIL_TOKEN_PATH": "/fake/token.json",
+                },
+            ),
+        ):
+            mock_auth_cls.return_value.get_service.side_effect = FileNotFoundError("no creds")
+            register_gmail_tools(mcp_server)
+
+        assert len(get_tool_names(mcp_server)) == 0
+
+    def test_no_tools_when_auth_fails(self, mcp_server):
+        with (
+            patch("gtd_mcp.gmail.tools.GmailAuth") as mock_auth_cls,
+            patch.dict(
+                os.environ,
+                {
+                    "GMAIL_CREDENTIALS_PATH": "/fake/creds.json",
+                    "GMAIL_TOKEN_PATH": "/fake/token.json",
+                },
+            ),
+        ):
+            mock_auth_cls.return_value.get_service.side_effect = RuntimeError("auth broke")
+            register_gmail_tools(mcp_server)
+
+        assert len(get_tool_names(mcp_server)) == 0
+
 
 # --- Delegation ---
 
@@ -131,6 +163,17 @@ class TestReadThread:
         fn(thread_id="t1")
 
         mock_client.read_thread.assert_called_once_with("t1")
+
+
+class TestListLabels:
+    def test_delegates(self, mcp_server, mock_gmail):
+        mock_client, _, _ = register_with_env(mcp_server, mock_gmail)
+        mock_client.list_labels.return_value = [{"id": "INBOX", "name": "INBOX"}]
+
+        fn = get_tool_fn(mcp_server, "list_gmail_labels")
+        result = fn()
+        mock_client.list_labels.assert_called_once()
+        assert result[0]["name"] == "INBOX"
 
 
 class TestArchive:

--- a/tests/test_gmail_tools.py
+++ b/tests/test_gmail_tools.py
@@ -80,6 +80,9 @@ class TestRegistration:
             "send_gmail",
             "send_gmail_draft",
             "trash_gmail_messages",
+            "list_gmail_attachments",
+            "read_gmail_attachment",
+            "download_gmail_attachment",
         }
         assert get_tool_names(mcp_server) == expected
 
@@ -256,3 +259,63 @@ class TestTrash:
         result = fn(message_ids=["m1", "m2"])
         mock_client.trash_messages.assert_called_once_with(["m1", "m2"])
         assert result["succeeded"] == 2
+
+
+# --- Attachment tools ---
+
+
+class TestListAttachmentsTool:
+    def test_delegates(self, mcp_server, mock_gmail):
+        mock_client, _, _ = register_with_env(mcp_server, mock_gmail)
+        mock_client.list_attachments.return_value = [
+            {"attachment_id": "att_1", "filename": "report.pdf"}
+        ]
+
+        fn = get_tool_fn(mcp_server, "list_gmail_attachments")
+        result = fn(message_id="msg_1")
+        mock_client.list_attachments.assert_called_once_with("msg_1")
+        assert result[0]["filename"] == "report.pdf"
+
+
+class TestReadAttachmentTool:
+    def test_delegates(self, mcp_server, mock_gmail):
+        mock_client, _, _ = register_with_env(mcp_server, mock_gmail)
+        mock_client.read_attachment_content.return_value = {
+            "filename": "data.csv",
+            "encoding": "text",
+            "content": "a,b\n1,2",
+        }
+
+        fn = get_tool_fn(mcp_server, "read_gmail_attachment")
+        result = fn(
+            message_id="msg_1",
+            attachment_id="att_1",
+            filename="data.csv",
+            mime_type="text/csv",
+        )
+        mock_client.read_attachment_content.assert_called_once_with(
+            "msg_1", "att_1", "data.csv", "text/csv"
+        )
+        assert result["encoding"] == "text"
+
+
+class TestDownloadAttachmentTool:
+    def test_delegates(self, mcp_server, mock_gmail):
+        mock_client, _, _ = register_with_env(mcp_server, mock_gmail)
+        mock_client.download_attachment.return_value = {
+            "filename": "report.pdf",
+            "path": "/tmp/report.pdf",
+            "size": 12345,
+        }
+
+        fn = get_tool_fn(mcp_server, "download_gmail_attachment")
+        result = fn(
+            message_id="msg_1",
+            attachment_id="att_1",
+            filename="report.pdf",
+            download_path="/tmp",
+        )
+        mock_client.download_attachment.assert_called_once_with(
+            "msg_1", "att_1", "report.pdf", "/tmp"
+        )
+        assert result["path"] == "/tmp/report.pdf"


### PR DESCRIPTION
## Summary
- Adds 3 new MCP tools: `list_gmail_attachments`, `read_gmail_attachment`, `download_gmail_attachment`
- `list_gmail_attachments` recursively extracts attachment metadata from multipart messages (excludes inline images)
- `read_gmail_attachment` returns content inline — text MIME types decoded as UTF-8, binary as base64
- `download_gmail_attachment` saves to disk with path traversal sanitization (`Path.name`)
- Enriches `read_gmail_message` output with `has_attachments` and `attachment_count` fields

## Test plan
- [x] 16 new unit tests across `test_gmail_client.py` and `test_gmail_tools.py` (75 total, all passing)
- [x] `ruff check` and `black --check` clean
- [ ] Manual smoke test: search for email with `has:attachment`, list attachments, download a PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)