### PR TITLE
fix(gmail): remove download_gmail_attachment tool

### DIFF
--- a/src/gtd_mcp/gmail/client.py
+++ b/src/gtd_mcp/gmail/client.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import base64
 import logging
 from email.mime.text import MIMEText
-from pathlib import Path
 
 from gtd_mcp.gmail.exceptions import GmailAPIError
 
@@ -136,12 +135,6 @@ class GmailClient:
             raise GmailAPIError(
                 f"Failed to get attachment {attachment_id} from {message_id}: {e}"
             ) from e
-
-    def download_attachment(self, message_id: str, attachment_id: str, filename: str) -> dict:
-        """Download an attachment and return raw bytes."""
-        raw_bytes = self.get_attachment(message_id, attachment_id)
-        safe_filename = Path(filename).name
-        return {"filename": safe_filename, "data": raw_bytes, "size": len(raw_bytes)}
 
     _TEXT_MIME_TYPES = frozenset({"application/json", "application/csv", "application/xml"})
 

--- a/src/gtd_mcp/gmail/tools.py
+++ b/src/gtd_mcp/gmail/tools.py
@@ -7,7 +7,6 @@ import os
 from typing import Annotated
 
 from fastmcp import FastMCP
-from fastmcp.resources import BinaryResource
 from pydantic import Field
 
 from gtd_mcp.gmail.auth import GmailAuth
@@ -454,7 +453,7 @@ def register_gmail_tools(mcp: FastMCP) -> None:
         """List attachments on a Gmail message.
 
         Returns metadata for each attachment (id, filename, mime_type, size).
-        Use with read_gmail_attachment() or download_gmail_attachment().
+        Use with read_gmail_attachment() to fetch content.
 
         Args:
             message_id: The message ID from search_gmail().
@@ -497,42 +496,6 @@ def register_gmail_tools(mcp: FastMCP) -> None:
              "encoding": "text", "content": "name,value\\nalice,42"}
         """
         return client.read_attachment_content(message_id, attachment_id, filename, mime_type)
-
-    @mcp.tool
-    def download_gmail_attachment(
-        message_id: Annotated[str, Field(description="The Gmail message ID.")],
-        attachment_id: Annotated[
-            str, Field(description="The attachment ID from list_gmail_attachments().")
-        ],
-        filename: Annotated[str, Field(description="Original filename of the attachment.")],
-    ) -> dict:
-        """Download a Gmail attachment, returning a resource URI to fetch it.
-
-        The attachment content is registered as an MCP resource. Use the
-        returned resource_uri to read the binary content via the MCP protocol.
-
-        Args:
-            message_id: The message ID.
-            attachment_id: The attachment ID from list_gmail_attachments().
-            filename: The attachment filename.
-
-        Example:
-            download_gmail_attachment(message_id="msg1", attachment_id="att1",
-                                     filename="report.pdf")
-
-        Returns:
-            {"filename": "report.pdf", "size": 12345,
-             "resource_uri": "attachment://gmail/msg1/report.pdf"}
-        """
-        result = client.download_attachment(message_id, attachment_id, filename)
-        uri = f"attachment://gmail/{message_id}/{result['filename']}"
-        resource = BinaryResource(uri=uri, data=result["data"])
-        mcp.add_resource(resource)
-        return {
-            "filename": result["filename"],
-            "size": result["size"],
-            "resource_uri": uri,
-        }
 
     # --- Delete ---
 

--- a/tests/test_gmail_client.py
+++ b/tests/test_gmail_client.py
@@ -778,34 +778,6 @@ class TestReadAttachmentContent:
 # --- Download attachment tests ---
 
 
-class TestDownloadAttachment:
-    def test_returns_bytes_and_metadata(self):
-        client, svc = make_client()
-        file_data = b"file contents"
-        encoded = base64.urlsafe_b64encode(file_data).decode()
-        svc.users().messages().attachments().get().execute.return_value = {
-            "data": encoded,
-            "size": len(file_data),
-        }
-
-        result = client.download_attachment("msg_1", "att_1", "report.pdf")
-        assert result["filename"] == "report.pdf"
-        assert result["data"] == file_data
-        assert result["size"] == len(file_data)
-
-    def test_path_traversal_sanitized(self):
-        client, svc = make_client()
-        file_data = b"data"
-        encoded = base64.urlsafe_b64encode(file_data).decode()
-        svc.users().messages().attachments().get().execute.return_value = {
-            "data": encoded,
-            "size": len(file_data),
-        }
-
-        result = client.download_attachment("msg_1", "att_1", "../../etc/passwd")
-        assert result["filename"] == "passwd"
-
-
 # --- _parse_full_message attachment fields ---
 
 

--- a/tests/test_gmail_tools.py
+++ b/tests/test_gmail_tools.py
@@ -82,7 +82,6 @@ class TestRegistration:
             "trash_gmail_messages",
             "list_gmail_attachments",
             "read_gmail_attachment",
-            "download_gmail_attachment",
         }
         assert get_tool_names(mcp_server) == expected
 
@@ -340,30 +339,3 @@ class TestReadAttachmentTool:
             "msg_1", "att_1", "data.csv", "text/csv"
         )
         assert result["encoding"] == "text"
-
-
-class TestDownloadAttachmentTool:
-    def test_delegates_and_registers_resource(self, mcp_server, mock_gmail):
-        mock_client, _, _ = register_with_env(mcp_server, mock_gmail)
-        mock_client.download_attachment.return_value = {
-            "filename": "report.pdf",
-            "data": b"pdf-bytes",
-            "size": 9,
-        }
-
-        fn = get_tool_fn(mcp_server, "download_gmail_attachment")
-        result = fn(
-            message_id="msg_1",
-            attachment_id="att_1",
-            filename="report.pdf",
-        )
-        mock_client.download_attachment.assert_called_once_with("msg_1", "att_1", "report.pdf")
-        assert result["filename"] == "report.pdf"
-        assert result["size"] == 9
-        assert result["resource_uri"] == "attachment://gmail/msg_1/report.pdf"
-        assert "path" not in result
-
-        # Verify resource was registered
-        resources = asyncio.new_event_loop().run_until_complete(mcp_server.list_resources())
-        uris = [str(r.uri) for r in resources]
-        assert "attachment://gmail/msg_1/report.pdf" in uris


### PR DESCRIPTION
## Summary
- Removes `download_gmail_attachment` tool — the `attachment://` resource URI approach doesn't work for MCP clients that can't resolve MCP resources (e.g. Cowork VM)
- Removes `client.download_attachment()` method and `BinaryResource` import — no longer needed
- `read_gmail_attachment` already handles both text (decoded inline) and binary (base64 inline) attachments, making the download tool redundant

## Test plan
- [x] `pytest tests/test_gmail_client.py tests/test_gmail_tools.py -v` — 81 tests pass
- [x] `ruff check src/gtd_mcp/gmail/` — clean
- [x] Verify `read_gmail_attachment` works for binary attachments (PDF, images) via Cowork

🤖 Generated with [Claude Code](https://claude.com/claude-code)