### PR TITLE
fix(todoist): clear due dates in batch_update_tasks

### DIFF
--- a/src/gtd_mcp/todoist/client.py
+++ b/src/gtd_mcp/todoist/client.py
@@ -321,7 +321,11 @@ class TodoistClient:
             if "labels" in op:
                 update_args["labels"] = op["labels"]
             if "due_date" in op:
-                update_args["due_string"] = op["due_date"]
+                due_val = op["due_date"]
+                if due_val is None or due_val == "" or due_val == "no date":
+                    update_args["due"] = None
+                else:
+                    update_args["due_string"] = due_val
             if "description" in op:
                 update_args["description"] = op["description"]
 

--- a/tests/test_todoist_batch.py
+++ b/tests/test_todoist_batch.py
@@ -107,6 +107,36 @@ class TestBuildSyncCommands:
 
         assert commands[0]["args"]["due_string"] == "2026-03-15"
 
+    def test_clear_due_date_with_none(self):
+        client, _, _ = make_client()
+
+        ops = [{"id": "task_1", "due_date": None}]
+        commands = client._build_sync_commands(ops)
+
+        args = commands[0]["args"]
+        assert args["due"] is None
+        assert "due_string" not in args
+
+    def test_clear_due_date_with_empty_string(self):
+        client, _, _ = make_client()
+
+        ops = [{"id": "task_1", "due_date": ""}]
+        commands = client._build_sync_commands(ops)
+
+        args = commands[0]["args"]
+        assert args["due"] is None
+        assert "due_string" not in args
+
+    def test_clear_due_date_with_no_date_string(self):
+        client, _, _ = make_client()
+
+        ops = [{"id": "task_1", "due_date": "no date"}]
+        commands = client._build_sync_commands(ops)
+
+        args = commands[0]["args"]
+        assert args["due"] is None
+        assert "due_string" not in args
+
     def test_description_included(self):
         client, _, _ = make_client()
 


### PR DESCRIPTION
## Summary
- When `batch_update_tasks` receives `due_date` as `null`, `""`, or `"no date"`, it now sends `{"due": null}` to the Sync API instead of an empty `due_string` that was silently ignored
- Adds 3 tests covering each clearing variant

## Test plan
- [x] `pytest tests/test_todoist_batch.py -v` — all 20 tests pass

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)